### PR TITLE
run vlan-nic setup script immediately not just on boot

### DIFF
--- a/roles/single-nic-firewall/tasks/main.yml
+++ b/roles/single-nic-firewall/tasks/main.yml
@@ -13,6 +13,10 @@
     group: root
     mode: '0700'
 
+- name: execute VLAN NIC config
+  command:
+    cmd: /etc/network/if-pre-up.d/vlan-setup
+
 - name: Template dnsmasq config
   template:
     src: dnsmasq.conf.j2 


### PR DESCRIPTION
this fixes nft service failing because vlan nics don't exist yet
if the pi hasn't been boot. As is the case on a first-deploy of this role.