### PR TITLE
Switch to Pulseaudio user mode for audio services

### DIFF
--- a/roles/autottylogin/tasks/main.yml
+++ b/roles/autottylogin/tasks/main.yml
@@ -39,7 +39,7 @@
 # This task is required because it's not possible to manage a systemd USER service
 # with ansible if you are not doing it while being that user
 # by enabling login with SSH for the media user we can handle enabling starting services as that user
-# in other tasks (all audio related for enableing audio related user services 
+# in other tasks (all audio related for enableing audio related user services
 - name: Deploy current users public SSH key for media user
   ansible.builtin.copy:
     remote_src: true

--- a/roles/autottylogin/tasks/main.yml
+++ b/roles/autottylogin/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Add media user
+  ansible.builtin.user:
+    name: media
+    createhome: true
+    groups: video,input
+
+- name: Enable autologin
+  ansible.builtin.file:
+    src: /lib/systemd/system/getty@.service
+    dest: /etc/systemd/system/getty.target.wants/getty@tty1.service
+    state: link
+
+- name: Enable autologin
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/getty@tty1.service.d/autologin.conf
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=-/sbin/agetty --autologin media --noclear %I $TERM
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Install ACL package (Required for ansible_become on media user in othe roles)
+  ansible.builtin.apt:
+    name: acl
+    state: present
+    install_recommends: false
+
+- name: Create .ssh folder
+  ansible.builtin.file:
+    path: /home/media/.ssh
+    state: directory
+    owner: media
+    group: media
+    mode: '0700'
+
+# This task is required because it's not possible to manage a systemd USER service
+# with ansible if you are not doing it while being that user
+# by enabling login with SSH for the media user we can handle enabling starting services as that user
+# in other tasks (all audio related for enableing audio related user services 
+- name: Deploy current users public SSH key for media user
+  ansible.builtin.copy:
+    remote_src: true
+    src: "/home/{{ lookup('env','USER') }}/.ssh/authorized_keys"
+    dest: /home/media/.ssh/authorized_keys
+    owner: media
+    group: media

--- a/roles/dns-over-tls/vars/main.yml
+++ b/roles/dns-over-tls/vars/main.yml
@@ -1,5 +1,4 @@
 ---
-
 # Cloudflare DNS related settings
 cloudflared_release_ver: https://github.com/cloudflare/cloudflared/releases/download/2023.7.1/
 
@@ -7,7 +6,6 @@ cloudflared_release_arch:
   amd64: cloudflared-linux-amd64.deb
   arm64: cloudflared-linux-arm64.deb
   armhf: cloudflared-linux-armhf.deb
-
 
 doh_dns_1: "1.1.1.1"
 doh_dns_2: "1.0.0.1"

--- a/roles/kodi/files/kodi.service
+++ b/roles/kodi/files/kodi.service
@@ -1,15 +1,13 @@
 [Unit]
 Description = Kodi Media Center
-After = remote-fs.target network-online.target
-Wants = network-online.target
+
+After=network-online.target
+Wants=network-online.target
 
 [Service]
-User=kodi
-Group=kodi
 Type=simple
 ExecStart=/usr/lib/aarch64-linux-gnu/kodi/kodi.bin --pulse
 Restart=on-failure
 
 [Install]
-WantedBy = multi-user.target
-
+WantedBy=default.target

--- a/roles/kodi/handlers/main.yml
+++ b/roles/kodi/handlers/main.yml
@@ -1,11 +1,17 @@
 ---
 - name: Restart kodi
+  become: false
+  remote_user: media
   ansible.builtin.systemd:
     name: kodi
     state: restarted
+    scope: user
   when: not ansible_check_mode
 
 
 - name: Reload systemd
+  become: false
+  remote_user: media
   ansible.builtin.systemd:
     daemon_reload: true
+    scope: user

--- a/roles/kodi/tasks/main.yml
+++ b/roles/kodi/tasks/main.yml
@@ -1,51 +1,58 @@
 ---
 
+- name: enable auto login on tty for media user (required for pulseaudio to work)
+  include_role:
+    name: autottylogin
+
 - name: Install packages
   ansible.builtin.apt:
     name: "{{ packages }}"
     update_cache: true
 
-- name: Add kodi user
-  ansible.builtin.user:
-    name: kodi
-    createhome: true
-    shell: /bin/false
-    password: false
-    system: true
-    groups: video,input,pulse-access
+- name: Create user systemd folder
+  ansible.builtin.file:
+    path: /home/media/.config/systemd/user/
+    state: directory
+    owner: media
+    group: media
+  tags: directory
 
 - name: Create Kodi service
   ansible.builtin.copy:
     src: ./files/kodi.service
-    dest: /etc/systemd/system/kodi.service
-    owner: kodi
-    group: kodi
+    dest: /home/media/.config/systemd/user/kodi.service
+    owner: media
+    group: media
     mode: '600'
   notify:
     - Reload systemd
-    - Restart kodi
 
-- name: Start Kodi on boot
+- name: Enable Kodi service
+  become: false
+  remote_user: media
   ansible.builtin.systemd:
     name: kodi
     state: started
     enabled: true
+    scope: user
+  notify:
+    - Reload systemd
   when: not ansible_check_mode
 
 - name: Create kodi settings folders
   ansible.builtin.file:
-    path: /home/kodi/.kodi/userdata
+    path: /home/media/.kodi/userdata
     state: directory
-    owner: kodi
-    group: kodi
+    owner: media
+    group: media
     mode: '700'
 
 - name: Setup kodi media sources
   ansible.builtin.copy:
     src: sources.xml
-    dest: /home/kodi/.kodi/userdata/sources.xml
-    owner: kodi
-    group: kodi
+    dest: /home/media/.kodi/userdata/sources.xml
+    owner: media
+    group: media
     mode: '644'
   notify: Restart kodi
   tags: sources

--- a/roles/kodi/vars/main.yml
+++ b/roles/kodi/vars/main.yml
@@ -1,9 +1,10 @@
 ---
 packages:
-  - kodi
-  - mesa-utils
+  - acl
   - ca-certificates
-  - samba-common-bin
   - cec-utils
-  - pulseaudio
+  - kodi
   - kodi-vfs-rar
+  - mesa-utils
+  - pulseaudio
+  - samba-common-bin

--- a/roles/librespot/tasks/main.yml
+++ b/roles/librespot/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 
-- name: Copy librespot for arm pulseaudio enabled version
+- name: Enable auto login on TTY for media user (required for audio to work)
+  include_role:
+    name: autottylogin
+
+- name: Copy librespot for ARM pulseaudio enabled version
   become: true
   ansible.builtin.copy:
     src: files/librespot.arm64_pulse
@@ -9,35 +13,27 @@
     group: root
     mode: '655'
 
-- name: Copy librespot and pulseaudio systemd service file
-  become: true
+- name: Create user systemd folder
+  ansible.builtin.file:
+    path: /home/media/.config/systemd/user/
+    state: directory
+    owner: media
+    group: media
+
+- name: Create librespot service
   ansible.builtin.template:
-    src: "{{ item }}"
-    dest: "/etc/systemd/system/{{ item }}"
-    owner: root
-    group: root
-    mode: '644'
-  loop:
-    - librespot.service
-    - pulseaudio-system-wide.service
-  tags: servicefile
+    src: librespot.service
+    dest: /home/media/.config/systemd/user/librespot.service
+    owner: media
+    group: media
+    mode: '600'
+  notify: Reload systemd
 
 - name: Install pulseaudio
   ansible.builtin.apt:
     name: pulseaudio
     state: present
     install_recommends: false
-
-- name: Disable per user pulseaudio sessions
-  ansible.builtin.systemd:
-    name: "{{ item }}"
-    enabled: false
-    state: stopped
-    scope: global
-  loop:
-    - pulseaudio.service
-    - pulseaudio.socket
-  when: not ansible_check_mode
 
 - name: Set default output to HDMI instead of analogue
   ansible.builtin.lineinfile:
@@ -49,31 +45,14 @@
     group: root
     mode: '0644'
 
-- name: Disable pulsaudio autospawn
-  ansible.builtin.lineinfile:
-    create: yes
-    path: /etc/pulse/client.conf
-    line: autospawn = no
-    insertbefore: EOF
-
-- name: Create librespot service user
-  ansible.builtin.user:
-    name: librespot
-    groups: pulse-access
-    system: true
-    shell: /bin/false
-    create_home: true
-    state: present
-
 - name: Enable librespot service
-  become: true
+  become: false
+  remote_user: media
   ansible.builtin.systemd:
-    name: "{{ item }}"
+    name: librespot
     state: started
     enabled: true
-    daemon_reload: true
-  when: not ansible_check_mode
+    scope: user
+  notify: Reload systemd
 
-  loop:
-    - librespot
-    - pulseaudio-system-wide
+  when: not ansible_check_mode

--- a/roles/librespot/templates/librespot.service
+++ b/roles/librespot/templates/librespot.service
@@ -6,8 +6,6 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-User=librespot
-
 ExecStart=/usr/local/bin/librespot.arm64_pulse -b 320 -n {{ spotify_connect_name }} -G -F speaker
 Restart=always
 RestartSec=5


### PR DESCRIPTION
This is a bit of a rewrite of how services that use audio work and contains a few hacks.

Pulseaudio isn't intended to "work" for a headless system (as in no user logged in) like a raspberry pi using a media center I circumvented this by forcing pulseaudio to run in a not-supported system wide mode. Which caused some issues for some new media services I've been wanting to use.

This work changes all media services to use pulseaudio as its intended as a "user" service.
Since the pulseaudio daemon is only spawned when a user is logged in. We let the media user that henceforth will run all audio applications to be autlogged in on tty1 not the prettiest solution but works.



