### PR TITLE
Add pactl and set initial volume

### DIFF
--- a/roles/librespot/tasks/main.yml
+++ b/roles/librespot/tasks/main.yml
@@ -38,10 +38,20 @@
   when: not ansible_check_mode
   tags: create_librespot_service
 
-- name: Install pipewire-pulse
+- name: Install pipewire-pulse and audio utilities
   ansible.builtin.apt:
-    name: pipewire-pulse
+    name:
+      - pipewire-pulse
+      - pipewire-audio-client-libraries
+      - pulseaudio-utils
     state: present
+
+- name: Set default sink volume to 100%
+  become: false
+  remote_user: media
+  ansible.builtin.command: pactl set-sink-volume @DEFAULT_SINK@ 100%
+  changed_when: false
+  when: not ansible_check_mode
 
 - name: Enable librespot service
   become: false


### PR DESCRIPTION
This pull request updates the audio setup tasks for the `librespot` role to improve system audio configuration and utility support. The main changes include installing additional audio-related packages and ensuring the default audio sink volume is set to 100%.

Audio package installation improvements:
* The `pipewire-pulse` installation step now also installs `pipewire-audio-client-libraries` and `pulseaudio-utils` to provide broader audio compatibility and utilities.

Audio configuration enhancements:
* A new task sets the default sink volume to 100% using `pactl`, ensuring maximum output volume for the audio sink. This runs as the `media` user and only when not in check mode.